### PR TITLE
Disable overwrite in copySync

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ USAGE
   $ iota-wiki-cli checkout
 
 OPTIONS
-  -h, --help  show CLI help
+  -h, --help            show CLI help
+  -o, --[no-]overwrite  Disable/Enable overwriting of static content
 
 EXAMPLE
   $ iota-wiki-cli checkout

--- a/lib/commands/checkout.d.ts
+++ b/lib/commands/checkout.d.ts
@@ -4,6 +4,7 @@ export default class Checkout extends Command {
     static examples: string[];
     static flags: {
         help: import("@oclif/parser/lib/flags").IBooleanFlag<void>;
+        overwrite: import("@oclif/parser/lib/flags").IBooleanFlag<boolean>;
     };
     run(): Promise<void>;
 }

--- a/lib/commands/checkout.js
+++ b/lib/commands/checkout.js
@@ -26,7 +26,7 @@ class Checkout extends command_1.Command {
                 stdio: 'inherit',
             });
             if (entry.staticPath) {
-                fs_extra_1.copySync(path_1.join(PWD, 'external', entry.repo.split('/').pop(), entry.staticPath), path_1.join(PWD, './static'), { overwrite: false });
+                fs_extra_1.copySync(path_1.join(PWD, 'external', entry.repo.split('/').pop(), entry.staticPath), path_1.join(PWD, './static'), { overwrite: flags.overwrite });
             }
         });
     }
@@ -38,4 +38,10 @@ Checkout.examples = [
 ];
 Checkout.flags = {
     help: command_1.flags.help({ char: 'h' }),
+    overwrite: command_1.flags.boolean({
+        char: 'o',
+        description: 'Disable/Enable overwriting of static content',
+        default: true,
+        allowNo: true
+    }),
 };

--- a/lib/commands/checkout.js
+++ b/lib/commands/checkout.js
@@ -26,7 +26,7 @@ class Checkout extends command_1.Command {
                 stdio: 'inherit',
             });
             if (entry.staticPath) {
-                fs_extra_1.copySync(path_1.join(PWD, 'external', entry.repo.split('/').pop(), entry.staticPath), path_1.join(PWD, './static'));
+                fs_extra_1.copySync(path_1.join(PWD, 'external', entry.repo.split('/').pop(), entry.staticPath), path_1.join(PWD, './static'), { overwrite: false });
             }
         });
     }

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -13,6 +13,12 @@ export default class Checkout extends Command {
 
   static flags = {
     help: flags.help({char: 'h'}),
+    overwrite: flags.boolean({ 
+      char: 'o',
+      description: 'Disable/Enable overwriting of static content',
+      default: true,
+      allowNo: true
+    }),
   }
 
   async run() {
@@ -35,7 +41,7 @@ export default class Checkout extends Command {
         stdio: 'inherit',
       })
       if(entry.staticPath) {
-        copySync(join(PWD, 'external', entry.repo.split('/').pop() as string, entry.staticPath), join(PWD, './static'), {overwrite: false})
+        copySync(join(PWD, 'external', entry.repo.split('/').pop() as string, entry.staticPath), join(PWD, './static'), {overwrite: flags.overwrite})
       }
     });
   }

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -35,7 +35,7 @@ export default class Checkout extends Command {
         stdio: 'inherit',
       })
       if(entry.staticPath) {
-        copySync(join(PWD, 'external', entry.repo.split('/').pop() as string, entry.staticPath), join(PWD, './static'))
+        copySync(join(PWD, 'external', entry.repo.split('/').pop() as string, entry.staticPath), join(PWD, './static'), {overwrite: false})
       }
     });
   }


### PR DESCRIPTION
We disabled overwrite in the old script so that already existing images in the wiki don't get overwritten.
For example the favicon 😅 Look at the current wiki :trollface: 
Don't know if this has any consequences for the content part of the cli tool, but I think it can be merged :)