### PR TITLE
Fixed while conditional

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -77,7 +77,7 @@ export default class Start extends Command {
      * @returns string
      */
     getGitRootDirectory(directory:string){
-        while(!existsSync(join(directory, '..')))
+        while(!existsSync(join(directory, '.git')))
         {
             directory = resolve(join(directory, '..'));
         }


### PR DESCRIPTION
When replacing (directory+'/.git')) with the join statement, I seem to have copied the wrong directory (Sorry!).  This wasn't caught before as it'd still work on docs only repos where it was tested, but it doesn't on regular repos.  